### PR TITLE
Improve exception handling for JSON fields

### DIFF
--- a/src/main/java/com/entwinemedia/fn/data/json/Field.java
+++ b/src/main/java/com/entwinemedia/fn/data/json/Field.java
@@ -27,6 +27,8 @@ public final class Field {
   private final JValue value;
 
   Field(String key, JValue value) {
+    if (value instanceof JPrimitive && ((JPrimitive) value).value() == null)
+      throw new IllegalArgumentException(String.format("Value of field '%s' must not be null", key));
     this.key = key;
     this.value = value;
   }


### PR DESCRIPTION
Since JSON data structures can become nested deeply, it's often quite
hard to find the origin of an error caused by an illegal value passed to
a field.

With this change, illegal fields will no longer be accepted and an
appropriate error message will be logged.