### PR TITLE
Add `toVavr` method to `Opt`; Update to Java 8; Set version to 1.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# ignore maven target directories
+target/
+
+# ignore Eclipse project data
+.project
+.classpath
+.metadata/
+.settings/
+.recommenders/
+
+# ignore NetBeans project data
+*/nbproject/*
+
+# Ignore all temporary editor files
+*.swp
+*.iml
+.idea/

--- a/Releasenotes.md
+++ b/Releasenotes.md
@@ -1,3 +1,8 @@
+Release 1.5.0
+-------------
+- Add `toVavr` method to `Opt`
+- Please note that this version now depends on vavr.io and requires Java 8
+
 Release 1.4.2
 -------------
 - Improve exception handling for JSON fields (#12)

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.entwinemedia.common</groupId>
   <artifactId>functional</artifactId>
-  <version>1.4.2</version>
+  <version>1.5.0</version>
   <name>functional</name>
   <description>A library for functional programming.</description>
   <inceptionYear>2013</inceptionYear>
@@ -33,6 +33,11 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vavr</groupId>
+      <artifactId>vavr</artifactId>
+      <version>0.9.0</version>
     </dependency>
     <!-- Testing -->
     <dependency>
@@ -80,8 +85,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/com/entwinemedia/fn/data/Opt.java
+++ b/src/main/java/com/entwinemedia/fn/data/Opt.java
@@ -24,6 +24,7 @@ import com.entwinemedia.fn.Stream;
 import com.entwinemedia.fn.StreamFold;
 import com.entwinemedia.fn.StreamOp;
 
+import io.vavr.control.Option;
 import java.util.Iterator;
 import java.util.List;
 
@@ -186,6 +187,10 @@ public abstract class Opt<A> implements Iterable<A> {
   @Override
   public final Iterator<A> iterator() {
     return toList().iterator();
+  }
+
+  public Option<A> toVavr() {
+    return Option.of(orNull());
   }
 
   @Override

--- a/src/test/java/com/entwinemedia/fn/StreamTest.java
+++ b/src/test/java/com/entwinemedia/fn/StreamTest.java
@@ -491,7 +491,7 @@ public class StreamTest {
     final StreamFold<Integer, Integer> sum = dbl.then(StreamFold.sum(Monoids.intAddition));
     final StreamFold<Object, String> mkString = StreamFold.mkString("-");
     assertEquals(new Integer(12), s.apply(sum));
-    assertEquals("4-8-12", s.apply(dbl.o(dbl).then(StreamFold.mkString("-"))));
+    assertEquals("4-8-12", s.apply(((StreamOp)dbl).o(dbl).then(StreamFold.mkString("-"))));
     assertEquals("1-2-3", s.apply(StreamFold.mk(mkString.toFn())));
   }
 

--- a/src/test/java/com/entwinemedia/fn/data/OptTest.java
+++ b/src/test/java/com/entwinemedia/fn/data/OptTest.java
@@ -107,4 +107,15 @@ public class OptTest {
     assertFalse(set.contains(a));
     assertEquals(0, set.size());
   }
+
+  @Test
+  public void testVavrSome() {
+    assertTrue(Opt.some("x").toVavr().isDefined());
+    assertEquals("x", Opt.some("x").toVavr().get());
+  }
+
+  @Test
+  public void testVavrNone() {
+    assertFalse(Opt.none(String.class).toVavr().isDefined());
+  }
 }


### PR DESCRIPTION
- Added a `toVavr` method to `Opt` to make the transition to Vavr easier
- Updated to Java 8 (required by Vavr)
- Set the version to 1.5.0